### PR TITLE
feat: Change title editor to contenteditable

### DIFF
--- a/src/TextEditor.tsx
+++ b/src/TextEditor.tsx
@@ -16,7 +16,7 @@ import ButtonGroup from "./components/ButtonGroup";
 import { EditorState, State } from "./Types";
 import Select from "./components/Select";
 import Input from "./components/Input";
-import EditableInput from "./components/EditableInput";
+import ContentEditable from "./components/ContentEditable";
 import * as t from "./Types";
 
 const useStyles = makeStyles({
@@ -182,19 +182,14 @@ const TextEditor = ({
         <div className="ql-editor hidden">hi</div>
         <div className="ql-toolbar ql-snow hidden">hi</div>
         <div className="mx-auto max-w-7xl px-sm lg:px-md mb-sm h-full">
-          <EditableInput
+          <ContentEditable
             value={state.title}
+            className="text-2xl mb-sm tracking-wide font-semibold text-darkest dark:text-lightest"
             onSubmit={(title) => {
               dispatch({ type: "setTitle", payload: title });
             }}
-          >
-            <h1 className="text-2xl mb-sm tracking-wide font-semibold text-darkest dark:text-lightest">
-              {state.title}
-              {!saved && (
-                <span className="text-xs text-gray-500">(unsaved changes)</span>
-              )}
-            </h1>
-          </EditableInput>
+            nextFocus={focus}
+          />
           {/* <ClickAwayListener onClickAway={handleClickAway}> */}
             <div onClick={onClickEditor} className="mb-md h-full w-full">
               <ReactQuill

--- a/src/components/ContentEditable.tsx
+++ b/src/components/ContentEditable.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+
+const DEFAULT_CLASSES = "focus:outline-none"
+
+export default function ContentEditable({
+  value,
+  onSubmit,
+  className = "",
+  nextFocus = null,
+}) {
+  const [content, setContent] = React.useState(value);
+  
+  const handleChange = evt => {
+    setContent(evt.target.innerHTML);
+  }
+  
+  const handleSubmit = () => {
+    onSubmit(content);
+  };
+  
+  const onKeyDown = (evt) => {
+    if ((evt.metaKey && evt.code == "KeyS") || evt.key === "Enter") {
+      evt.preventDefault();
+      onSubmit(content);
+      if (nextFocus) {
+        nextFocus();
+      }
+    }
+  }
+  
+  return (
+    <div
+      className={`${DEFAULT_CLASSES} ${className}`}
+      contentEditable={true}
+      suppressContentEditableWarning
+      onBlur={handleSubmit}
+      onKeyDown={onKeyDown}
+      onInput={handleChange}
+    >
+      {value}
+    </div>
+  )
+}


### PR DESCRIPTION
This adds a simple contenteditable component that allows users to change the title by just focusing on said element. Upon pressing cmd+S, enter, or causing a blur event, the title will save.

Before:
![Before](https://user-images.githubusercontent.com/18686786/230286237-3e558754-79b0-4162-8ed2-3aeed26166a2.gif)


After:
![now](https://user-images.githubusercontent.com/18686786/230286247-596d6427-baf2-4943-9fcb-3054721d7a48.gif)
