### PR TITLE
fix: force side menus open on first load

### DIFF
--- a/src/BookList.tsx
+++ b/src/BookList.tsx
@@ -12,11 +12,13 @@ export default function BookList({
   selectedBookId,
   onChange,
   closeSidebar,
+  canCloseSidebar = true,
 }: {
   books: t.Book[];
   selectedBookId: string;
   onChange: () => void;
   closeSidebar: () => void;
+  canCloseSidebar?: boolean;
 }) {
   async function deleteBook(bookid: string) {
     const res = await fetch(`/api/deleteBook`, {
@@ -86,8 +88,14 @@ export default function BookList({
   lists.push(sublist("All", otherBooks));
 
   const buttonStyles = "bg-dmsidebar dark:hover:bg-dmsidebarSecondary";
-  const rightMenuItem =
-    { label: "Close", icon: <XMarkIcon className="w-4 h-4" />, onClick: closeSidebar, className: buttonStyles }
+  const buttonStylesDisabled = `${buttonStyles} disabled:opacity-50`
+  const rightMenuItem = canCloseSidebar &&
+    {
+      label: "Close",
+      icon: <XMarkIcon className="w-4 h-4" />,
+      onClick: closeSidebar,
+      className: buttonStyles
+    };
   
     const leftMenuItem =
     { label: "New", icon: <PlusIcon className="w-4 h-4" />, onClick: newBook, className: buttonStyles }

--- a/src/ChapterList.tsx
+++ b/src/ChapterList.tsx
@@ -14,12 +14,14 @@ export default function ChapterList({
   selectedChapterId,
   onChange,
   closeSidebar,
+  canCloseSidebar = true,
 }: {
   chapters: t.Chapter[];
   bookid: string;
   selectedChapterId: string;
   onChange: () => void;
   closeSidebar: () => void;
+  canCloseSidebar?: boolean;
 }) {
   async function deleteChapter(chapterid: string) {
     console.log("delete chapter", chapterid);
@@ -95,7 +97,7 @@ export default function ChapterList({
   lists.push(sublist("All", otherChapters));
 
   const buttonStyles = "bg-dmsidebarSecondary dark:hover:bg-dmsidebar";
-  const rightMenuItem =
+  const rightMenuItem = canCloseSidebar &&
     { label: "Close", icon: <XMarkIcon className="w-4 h-4" />, onClick: closeSidebar, className: buttonStyles }
   
     const newMenuItem =

--- a/src/Library.tsx
+++ b/src/Library.tsx
@@ -38,6 +38,9 @@ export default function Library() {
  */
 
   const fetchBook = async () => {
+    if (!bookid) {
+      return;
+    };
     const result = await fd.fetchBook(bookid);
     if (result.tag === "success") {
       dispatch({ type: "SET_BOOK", payload: result.payload });
@@ -47,8 +50,24 @@ export default function Library() {
   }
 
   useEffect(() => {
-  fetchBook();
+    fetchBook();
   }, [bookid]);
+  
+  // if the chapter id is null set the book list open to true
+  // so that we do not end up with an empty screen.
+  useEffect(() => {
+    if (!chapterid) {
+      setBookListOpen(true);
+    }
+  }, [chapterid]);
+  
+  // Force the chapter list open if a chapter has not been selected but a
+  // book has.
+  useEffect(() => {
+    if (!chapterid && state.selectedBook) {
+      setChapterListOpen(true);
+    }
+  }, [state.selectedBook, chapterid])
 
   const fetchBooks = async () => {
     const res = await fetch(`/books`);
@@ -93,6 +112,7 @@ const bothListsClosed = !bookListOpen && !chapterListOpen;
             selectedBookId={selectedBookId}
             onChange={fetchBooks}
             closeSidebar={() => setBookListOpen(false)}
+            canCloseSidebar={chapterid !== undefined}
           />
         </div>}
         {chapterListOpen && state.selectedBook && (
@@ -103,6 +123,7 @@ const bothListsClosed = !bookListOpen && !chapterListOpen;
               selectedChapterId={chapterid || ""}
               onChange={() => fetchBook()}
               closeSidebar={() => setChapterListOpen(false)}
+              canCloseSidebar={chapterid !== undefined || !state.selectedBook}
             />
           </div>
         )}
@@ -117,6 +138,7 @@ const bothListsClosed = !bookListOpen && !chapterListOpen;
           }} bookListOpen={bookListOpen}
            chapterListOpen={ chapterListOpen}
           />}
+          {/*  we run a risk of the book id being closed and not being able to be reopened */}
         </div>
       </div>
     </div>


### PR DESCRIPTION
There is an issue with the sidebar state loading to localstorage in which you can end up with a black screen and now way out (without deleting your localstorage).

This change tries to reduce the architectural impact by just forcing menus to be open if a chapter is not selected, and not allowing them to be closed if a chapter is not selected or in the case of the chapter menu, if a book is selected.

Before
![broken-sidebar](https://user-images.githubusercontent.com/18686786/230539869-c89f39d0-3fee-4f1e-80fa-4b2c4c827370.gif)

After
![fix-sidebar-before](https://user-images.githubusercontent.com/18686786/230539883-c50c3257-8e03-433d-88e7-6e13e67ea29d.gif)

