### PR TITLE
fix: fix add chapter button

### DIFF
--- a/server.js
+++ b/server.js
@@ -135,7 +135,7 @@ app.post("/api/newChapter", requireLogin, async (req, res) => {
 
       //book.chapters.push(chapter);
       await saveChapter(chapter);
-      res.redirect(`/chapter/${chapterid}`);
+      res.redirect(`/api/chapter/${chapterid}`);
     }
   }
 });


### PR DESCRIPTION
The add chapter button was not working because it would error out on redirect. This mean that whenever a chapter was added, nothing would appear on the screen until refresh occured.